### PR TITLE
Downgrade Rails to match ror40 SCL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,12 +19,14 @@ gem 'oauth', '~> 0.4'
 gem 'deep_cloneable', '~> 2.0'
 gem 'foreigner', '~> 1.4'
 gem 'validates_lengths_from_database',  '~> 0.2'
-gem 'friendly_id', '~> 4.0'
+gem 'friendly_id', '~> 5.0'
 gem 'secure_headers', '~> 1.3'
 gem 'safemode', '~> 1.2'
 gem 'ruby_parser', '3.1.1'
 gem 'fast_gettext', '~> 0.8'
 gem 'gettext_i18n_rails', '~> 1.0'
+gem 'activerecord-session_store'
+gem 'protected_attributes'
 
 Dir["#{File.dirname(FOREMAN_GEMFILE)}/bundler.d/*.rb"].each do |bundle|
   self.instance_eval(Bundler.read_file(bundle))

--- a/Gemfile
+++ b/Gemfile
@@ -5,10 +5,10 @@ require File.expand_path('../lib/regexp_extensions', FOREMAN_GEMFILE)
 
 source 'https://rubygems.org'
 
-gem 'rails', '3.2.21'
+gem 'rails', '4.0.12'
 gem 'json', '~> 1.5'
 gem 'rest-client', '~> 1.6.0', :require => 'rest_client'
-gem 'audited-activerecord', '3.0.0'
+gem 'audited-activerecord'#, '3.0.0'
 gem 'will_paginate', '~> 3.0'
 gem 'ancestry', '~> 2.0'
 gem 'scoped_search', '~> 2.7'

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ require File.expand_path('../lib/regexp_extensions', FOREMAN_GEMFILE)
 
 source 'https://rubygems.org'
 
-gem 'rails', '4.0.12'
+gem 'rails', '4.0.2'
 gem 'json', '~> 1.5'
 gem 'rest-client', '~> 1.6.0', :require => 'rest_client'
 gem 'audited-activerecord'#, '3.0.0'

--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -8,7 +8,7 @@ module HostCommon
   included do
     include CounterCacheFix
 
-    counter_cache = "#{model_name.split(":").first.pluralize.downcase}_count".to_sym  # e.g. :hosts_count
+    counter_cache = "#{model_name.to_s.split(":").first.pluralize.downcase}_count".to_sym  # e.g. :hosts_count
 
     belongs_to :architecture,    :counter_cache => counter_cache
     belongs_to :environment,     :counter_cache => counter_cache

--- a/app/models/concerns/taxonomix.rb
+++ b/app/models/concerns/taxonomix.rb
@@ -4,7 +4,7 @@ module Taxonomix
 
   included do
     taxonomy_join_table = "taxable_taxonomies"
-    has_many taxonomy_join_table, :dependent => :destroy, :as => :taxable
+    has_many taxonomy_join_table.to_sym, :dependent => :destroy, :as => :taxable
     has_many :locations,     :through => taxonomy_join_table, :source => :taxonomy,
              :conditions => "taxonomies.type='Location'", :validate => false
     has_many :organizations, :through => taxonomy_join_table, :source => :taxonomy,

--- a/bundler.d/assets.rb
+++ b/bundler.d/assets.rb
@@ -1,19 +1,19 @@
 group :assets do
-  gem 'sass-rails', '~> 3.2'
+  gem 'sass-rails'#, '~> 3.2'
   gem 'uglifier', '>= 1.0.3'
   gem 'execjs', '>= 1.4.0'
   gem 'jquery-rails', '2.0.3'
   gem 'jquery-ui-rails', '< 5.0.0'
   gem 'therubyracer', '0.11.3', :require => 'v8'
   gem 'bootstrap-sass', '3.0.3.0'
-  gem 'spice-html5-rails', '~> 0.1.4'
+  #gem 'spice-html5-rails'#, '~> 0.1.4'
   gem 'flot-rails', '0.0.3'
   gem 'quiet_assets', '~> 1.0'
-  gem 'gettext_i18n_rails_js', '~> 0.0', '>= 0.0.8'
+  #gem 'gettext_i18n_rails_js'#, '~> 0.0', '>= 0.0.8'
   # unspecified dep of gettext_i18n_rails_js
   #   https://github.com/nubis/gettext_i18n_rails_js/pull/23
   gem 'gettext', '~> 3.1', :require => false
   gem 'multi-select-rails', '~> 0.9'
-  gem 'gridster-rails', '~> 0.1'
-  gem 'jquery_pwstrength_bootstrap', '~> 1.2'
+  #gem 'gridster-rails'#, '~> 0.1'
+  #gem 'jquery_pwstrength_bootstrap'#, '~> 1.2'
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -54,7 +54,10 @@ end
 module Foreman
   class Application < Rails::Application
     # Setup additional routes by loading all routes file from routes directory
-    config.paths["config/routes"] += Dir[Rails.root.join("config/routes/**/*.rb")]
+
+    Dir["#{Rails.root}/config/routes/**/*.rb"].each do |route_file|
+      config.paths['config/routes.rb'] << route_file
+    end
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Foreman::Application.routes.draw do
   end
 
   #ENC requests goes here
-  match "node/:name" => 'hosts#externalNodes', :constraints => { :name => /[^\.][\w\.-]+/ }
+  get "node/:name" => 'hosts#externalNodes', :constraints => { :name => /[^\.][\w\.-]+/ }
 
   resources :reports, :only => [:index, :show, :destroy] do
     collection do
@@ -16,7 +16,7 @@ Foreman::Application.routes.draw do
     end
   end
 
-  match '(:controller)/help', :action => 'welcome', :as => "help"
+  get '(:controller)/help', :action => 'welcome', :as => "help"
   constraints(:id => /[^\/]+/) do
     resources :hosts do
       member do
@@ -110,7 +110,7 @@ Foreman::Application.routes.draw do
     end
 
     constraints(:hostgroup => /[^\/]+/) do
-      match 'unattended/template/:id/:hostgroup', :to => "unattended#template"
+      get 'unattended/template/:id/:hostgroup', :to => "unattended#template"
     end
   end
 
@@ -351,16 +351,16 @@ Foreman::Application.routes.draw do
   end
 
   root :to => 'dashboard#index'
-  match 'dashboard', :to => 'dashboard#index', :as => "dashboard"
-  match 'dashboard/auto_complete_search', :to => 'hosts#auto_complete_search', :as => "auto_complete_search_dashboards"
-  match 'statistics', :to => 'statistics#index', :as => "statistics"
-  match 'status', :to => 'home#status', :as => "status"
+  get 'dashboard', :to => 'dashboard#index', :as => "dashboard"
+  get 'dashboard/auto_complete_search', :to => 'hosts#auto_complete_search', :as => "auto_complete_search_dashboards"
+  get 'statistics', :to => 'statistics#index', :as => "statistics"
+  get 'status', :to => 'home#status', :as => "status"
 
   # match only for alterator unattended scripts
-  match 'unattended/provision/:metadata', :controller => 'unattended', :action => 'provision', :format => 'html',
+  get 'unattended/provision/:metadata', :controller => 'unattended', :action => 'provision', :format => 'html',
     :constraints => { :metadata => /(autoinstall\.scm|vm-profile\.scm|pkg-groups\.tar)/ }
   # match for all unattended scripts
-  match 'unattended/(:action/(:id(.format)))', :controller => 'unattended'
+  get 'unattended/(:action/(:id(.format)))', :controller => 'unattended'
 
   resources :tasks, :only => [:show]
 
@@ -369,7 +369,7 @@ Foreman::Application.routes.draw do
       resources :hosts, :only => :index
       member do
         get 'select'
-        match "clone" => 'locations#clone_taxonomy'
+        get "clone" => 'locations#clone_taxonomy'
         get 'nest'
         post 'import_mismatches'
         get 'step2'
@@ -391,7 +391,7 @@ Foreman::Application.routes.draw do
     resources :organizations, :except => [:show] do
       member do
         get 'select'
-        match "clone" => 'organizations#clone_taxonomy'
+        get "clone" => 'organizations#clone_taxonomy'
         get 'nest'
         post 'import_mismatches'
         get 'step2'

--- a/config/routes/api/v1.rb
+++ b/config/routes/api/v1.rb
@@ -68,8 +68,8 @@ Foreman::Application.routes.draw do
       resources :users, :except => [:new, :edit]
       resources :template_kinds, :only => [:index]
 
-      match '/', :to => 'home#index'
-      match 'status', :to => 'home#status', :as => "status"
+      get '/', :to => 'home#index'
+      get 'status', :to => 'home#status', :as => "status"
     end
 
   end

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -169,8 +169,8 @@ Foreman::Application.routes.draw do
 
       resources :statistics, :only => [:index]
 
-      match '/', :to => 'home#index'
-      match 'status', :to => 'home#status', :as => "status"
+      get '/', :to => 'home#index'
+      get 'status', :to => 'home#status', :as => "v2_status"
 
       resources :reports, :only => [:create]
 


### PR DESCRIPTION
As a temporary measure during development on this branch, downgrade Rails 4 to
version 4.0.2 to match the version shipped in the RHSCL ror40 collection, to
avoid introducing incompatibilities by depending on features in newer versions.

It can be reverted to 4.0.latest for production usage once the work's complete.
